### PR TITLE
Bug 1113160 - add git fetch to get new branches for deploying

### DIFF
--- a/deployment/update/update.py
+++ b/deployment/update/update.py
@@ -28,15 +28,17 @@ sys.path.append(th_service_src)
 def pre_update(ctx, ref=settings.UPDATE_REF):
     """Update the code to a specific git reference (tag/sha/etc)."""
     with ctx.lcd(th_service_src):
+        ctx.local('git fetch --prune')
+        ctx.local('git reset FETCH_HEAD --hard')
         ctx.local('git checkout %s' % ref)
-        ctx.local('git pull -f')
         ctx.local('git submodule sync')
         ctx.local('git submodule update --init --recursive')
         ctx.local("find . -type f -name '*.pyc' -delete")
 
     with ctx.lcd(th_ui_src):
+        ctx.local('git fetch --prune')
+        ctx.local('git reset FETCH_HEAD --hard')
         ctx.local('git checkout %s' % ref)
-        ctx.local('git pull -f')
         ctx.local('git submodule sync')
         ctx.local('git submodule update --init --recursive')
         ctx.local("find . -type f -name '*.pyc' -delete")


### PR DESCRIPTION
Without this fetch, you can only deploy to branches that existed when the LAST deploy was done.  By doing ``git fetch`` you get any new branches that were created since the last deploy.  This allows the ``git checkout`` to succeed on line 32.