### PR TITLE
Bug 1086896 - Use the log step finish line for determining result

### DIFF
--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -134,7 +134,6 @@ class StepParser(ParserBase):
                     "started": match.group('timestamp'),
                     "started_linenumber": lineno,
                     "order": self.stepnum,
-                    "result": RESULT_DICT.get(int(match.group('result')), "unknown"),
                     "errors": [],
                 })
                 return
@@ -148,6 +147,7 @@ class StepParser(ParserBase):
                 self.current_step.update({
                     "finished": match.group('timestamp'),
                     "finished_linenumber": lineno,
+                    "result": RESULT_DICT.get(int(match.group('result')), "unknown"),
                     "errors": self.sub_parser.get_artifact(),
                 })
                 self.set_duration()


### PR DESCRIPTION
For buildbot jobs there are headers/separators at the start and end of
each step within the job log, which contain various stats about the
step. Since buildbot buffers the output, it's able to add the result for
the current step to not just the end separator, but the start one too.

However, for non-buildbot submitters of results, they may not buffer the
output, and so cannot output the step result in the start line, only the
end one. As such, this commit switches the log parser to using the
latter instead of the former to determine the step result.