### PR TITLE
Bug 1118266 - Remove '/ui' from logviewer URLs in TBPLbot comments

### DIFF
--- a/tests/etl/test_tbpl.py
+++ b/tests/etl/test_tbpl.py
@@ -83,7 +83,7 @@ def test_tbpl_bugzilla_request_body(jm, eleven_jobs_processed):
 
     expected = {
         'comment': (u'submit_timestamp: {0}\n'
-                    u'log: http://local.treeherder.mozilla.org/ui/'
+                    u'log: http://local.treeherder.mozilla.org/'
                     u'logviewer.html#?repo=test_treeherder&job_id=1\n'
                     u'repository: test_treeherder\n'
                     u'who: user[at]mozilla[dot]com\n'

--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -123,9 +123,8 @@ class BugzillaBugRequest(object):
             'repository': self.project,
             'who': who,
             'submit_timestamp': submit_date,
-            'log': "{0}{1}/logviewer.html#?repo={2}&job_id={3}".format(
+            'log': "{0}/logviewer.html#?repo={1}&job_id={2}".format(
                 settings.SITE_URL,
-                settings.UI_PREFIX,
                 self.project,
                 self.job_id
             ),

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -372,9 +372,6 @@ CELERY_IGNORE_RESULT = True
 
 API_HOSTNAME = SITE_URL
 
-# this is used to compose ui urls
-UI_PREFIX = "/ui"
-
 BROWSERID_AUDIENCES = [SITE_URL]
 
 


### PR DESCRIPTION
Leftover from bug 1063411.