### PR TITLE
Bug 1119028 - Only ingest last 21 revisions per resultset

### DIFF
--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -40,7 +40,8 @@ class HgPushlogTransformerMixin(object):
             rev_hash_components = []
 
             # iterate over the revisions
-            for change in push['changesets']:
+            # we only want to ingest the last 200 revisions.
+            for change in push['changesets'][-200:]:
                 revision = dict()
                 # we need to get the short version of a revision
                 # because buildapi doesn't provide the long one


### PR DESCRIPTION
We only use the latest 20 revisions.  And fetching 21 will tell us there is "more" and that we should link to the repo change log.