### PR TITLE
Bug 1085100 - Use start_time instead of classification time in bug comments

### DIFF
--- a/tests/etl/test_tbpl.py
+++ b/tests/etl/test_tbpl.py
@@ -63,7 +63,6 @@ def test_tbpl_bugzilla_request_body(jm, eleven_jobs_processed):
     job = jm.get_job_list(0, 1)[0]
 
     submit_timestamp = int(time())
-    submit_date = datetime.fromtimestamp(submit_timestamp).isoformat()
     who = "user@mozilla.com"
     jm.insert_bug_job_map(job['id'], bug_id, "manual", submit_timestamp, who)
 
@@ -82,15 +81,15 @@ def test_tbpl_bugzilla_request_body(jm, eleven_jobs_processed):
     req.generate_request_body()
 
     expected = {
-        'comment': (u'submit_timestamp: {0}\n'
-                    u'log: http://local.treeherder.mozilla.org/'
+        'comment': (u'log: http://local.treeherder.mozilla.org/'
                     u'logviewer.html#?repo=test_treeherder&job_id=1\n'
                     u'repository: test_treeherder\n'
+                    u'start_time: 2013-11-13T06:39:13\n'
                     u'who: user[at]mozilla[dot]com\n'
                     u'machine: bld-linux64-ec2-132\n'
                     u'revision: cdfe03e77e66\n\n'
                     u'First error line\n'
-                    u'Second error line').format(submit_date)
+                    u'Second error line')
     }
 
     assert req.body == expected

--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -117,14 +117,12 @@ class BugzillaBugRequest(object):
         who = bug_job_map["who"]\
             .replace("@", "[at]")\
             .replace(".", "[dot]")
-        submit_date = datetime.fromtimestamp(bug_job_map["submit_timestamp"])\
-            .replace(microsecond=0)\
-            .isoformat()
+        start_time = datetime.fromtimestamp(job["start_timestamp"]).isoformat()
 
         job_description = {
             'repository': self.project,
             'who': who,
-            'submit_timestamp': submit_date,
+            'start_time': start_time,
             'log': "{0}/logviewer.html#?repo={1}&job_id={2}".format(
                 settings.SITE_URL,
                 self.project,


### PR DESCRIPTION
Previously classifying failures with a bug number would add a comment to
the bug that listed the datetime of classification. However this is
redundant, since it's virtually the same as the datetime of the bug
comment itself. Instead, it's more useful to list the job start time.

Only classifications for completed jobs are submitted to Bugzilla, so we
do not need to add handling for pending jobs, that do not have a start
time.