### PR TITLE
Bug 1086663 - Make the TinderboxPrint regex less strict about whitespace

### DIFF
--- a/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.jobartifact.json
+++ b/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.jobartifact.json
@@ -1,5 +1,6 @@
 {
     "job_details": [
+        {"content_type": "raw_html", "value": "<a href=http://hg.mozilla.org/releases/mozilla-esr17/rev/e2eecb449eeb title=\"Built from revision e2eecb449eeb\">rev:e2eecb449eeb</a>\r"},
         {"content_type": "raw_html", "value": "31776/<em class=\"testfail\">2</em>/40", "title": "mochitest-browser-chrome"}
     ],
     "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/mozilla-esr17_xp_test_pgo-mochitest-browser-chrome-bm74-tests1-windows-build12.txt.gz"

--- a/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.jobartifact.json
+++ b/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.jobartifact.json
@@ -1,4 +1,7 @@
 {
-    "job_details": [],
+    "job_details": [
+        {"content_type": "raw_html", "value": "<a href=http://hg.mozilla.org/projects/ux/rev/546ccc10a18f title=\"Built from revision 546ccc10a18f\">rev:546ccc10a18f</a>"},
+        {"content_type": "raw_html", "value": "7270/6", "title": "jetpack"}
+    ],
     "logurl": "file:///home/vagrant/treeherder-service/tests/sample_data/logs/ux_ubuntu32_vm_test-jetpack-bm67-tests1-linux-build16.txt.gz"
 }

--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -188,7 +188,7 @@ class StepParser(ParserBase):
         return self.steps[self.stepnum]
 
 
-RE_TINDERBOXPRINT = re.compile('.*TinderboxPrint: (?P<line>.*)$')
+RE_TINDERBOXPRINT = re.compile('.*TinderboxPrint: ?(?P<line>.*)$')
 
 RE_UPLOADED_TO = re.compile(
     "<a href=['\"](?P<url>http(s)?://.*)['\"]>(?P<value>.+)</a>: uploaded"


### PR DESCRIPTION
So that we don't miss "Built from revision X" TinderboxPrints.