### PR TITLE
Bug 1067409 - Filter on repository active_status in more cases

### DIFF
--- a/treeherder/model/management/commands/init_datasources.py
+++ b/treeherder/model/management/commands/init_datasources.py
@@ -44,7 +44,7 @@ Type 'yes' to continue, or 'no' to cancel: """)
                 for ds in Datasource.objects.all():
                     ds.delete()
 
-        projects = Repository.objects.all().values_list('name', flat=True)
+        projects = Repository.objects.filter(active_status='active').values_list('name', flat=True)
         for project in projects:
             for contenttype in ("jobs", "objectstore"):
                 Datasource.objects.get_or_create(

--- a/treeherder/model/tasks.py
+++ b/treeherder/model/tasks.py
@@ -41,7 +41,7 @@ def cycle_data():
 @task(name='calculate-eta', rate_limit='1/h')
 def calculate_eta(sample_window_seconds=21600, debug=False):
 
-    projects = Repository.objects.all().values_list('name', flat=True)
+    projects = Repository.objects.filter(active_status='active').values_list('name', flat=True)
 
     for project in projects:
 


### PR DESCRIPTION
We should only include active repositories when performing
init_datasources or calculating job etas.