### PR TITLE
Bug 1059811 - Fix remaining pyflakes warnings

### DIFF
--- a/tests/etl/test_tbpl.py
+++ b/tests/etl/test_tbpl.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from datetime import datetime
 from treeherder.etl.tbpl import OrangeFactorBugRequest, BugzillaBugRequest
 import json
 from time import time

--- a/treeherder/__init__.py
+++ b/treeherder/__init__.py
@@ -1,8 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery import app as celery_app
+from .celery import app as celery_app  # noqa
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 path = lambda *a: os.path.join(PROJECT_DIR, *a)
-

--- a/treeherder/etl/daemon.py
+++ b/treeherder/etl/daemon.py
@@ -68,7 +68,7 @@ class Daemon(object):
 	def delpid(self):
 		try:
 			os.remove(self.pidfile)
-		except OSError, e:
+		except OSError:
 			pass
 
 	def start(self):

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -894,8 +894,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
               ...
                 }
             """
-        where_in_clause = ','.join(where_in_list)
-
         result_set_id_lookup = {}
 
         if revision_hashes:
@@ -2175,13 +2173,7 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         tda = TalosDataAdapter()
 
         for perf_data in performance_artifact_placeholders:
-
             job_guid = perf_data["job_guid"]
-
-            job_id = job_data.get(
-                perf_data['job_guid'], {}
-                ).get('id', None)
-
             ref_data_signature = job_data[job_guid]['signature']
             ref_data = reference_data[ ref_data_signature ]
 

--- a/treeherder/workers/models.py
+++ b/treeherder/workers/models.py
@@ -2,6 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-from django.db import models
+from django.db import models  # noqa
 
 # Create your models here.


### PR DESCRIPTION
This fixes:
tests/etl/test_tbpl.py:5:1: F401 'datetime' imported but unused
treeherder/__init__.py:4:1: F401 'celery_app' imported but unused
treeherder/etl/daemon.py:71:19: F841 local variable 'e' is assigned to but never used
treeherder/model/derived/jobs.py:893:9: F841 local variable 'where_in_clause' is assigned to but never used
treeherder/model/derived/jobs.py:2177:13: F841 local variable 'job_id' is assigned to but never used
treeherder/workers/models.py:5:1: F401 'models' imported but unused

However I'm dubious about the unused 'where_in_clause' in jobs.py - it looks perhaps that it was intended to have been passed to jobs_execute()'s 'replace', here:
https://github.com/mozilla/treeherder-service/blob/c99cc67a70ed94f6694b9bed968373edb89e4fd2/treeherder/model/derived/jobs.py#L899