### PR TITLE
Bug 1124270 - fix parsing step dates without decimal

### DIFF
--- a/tests/log_parser/test_step_parser.py
+++ b/tests/log_parser/test_step_parser.py
@@ -1,0 +1,15 @@
+from treeherder.log_parser.parsers import StepParser
+from datetime import datetime
+
+def test_date_with_milliseconds():
+    """Handle buildbot dates that have a decimal on the seconds."""
+    parser = StepParser()
+    dt = parser.parsetime('2015-01-20 16:42:33.352621')
+    assert dt == datetime(2015, 1, 20, 16, 42, 33, 352621)
+
+def test_date_without_milliseconds():
+    """Handle buildbot dates that DON'T have a decimal on the seconds."""
+    parser = StepParser()
+    dt = parser.parsetime('2015-01-20 16:42:33')
+    assert dt == datetime(2015, 1, 20, 16, 42, 33)
+

--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -165,6 +165,10 @@ class StepParser(ParserBase):
 
     def parsetime(self, match):
         """Convert a string date into a datetime."""
+        # DATE_FORMAT expects a decimal on the seconds.  If it's not
+        # present, we must add it so the date parsing does not fail.
+        if not "." in match:
+            match = "{0}.0".format(match)
         return datetime.datetime.strptime(match, self.DATE_FORMAT)
 
     def set_duration(self):


### PR DESCRIPTION
sometimes the dates in the buildbot steps are not quite the format we
expect.  Massage them to match so we don’t fail log parsing.