### PR TITLE
Bug 1124269 - Add smarter celery retry times

### DIFF
--- a/treeherder/etl/tasks/tbpl_tasks.py
+++ b/treeherder/etl/tasks/tbpl_tasks.py
@@ -20,7 +20,9 @@ def submit_star_comment(project, job_id, bug_id, submit_timestamp, who):
         req.generate_request_body()
         req.send_request()
     except Exception, e:
-        submit_star_comment.retry(exc=e)
+        # Initially retry after 1 minute, then for each subsequent retry
+        # lengthen the retry time by another minute.
+        submit_star_comment.retry(exc=e, countdown=(1 + submit_star_comment.request.retries) * 60)
         # this exception will be raised once the number of retries
         # exceeds max_retries
         raise
@@ -37,7 +39,9 @@ def submit_bug_comment(project, job_id, bug_id):
         req.generate_request_body()
         req.send_request()
     except Exception, e:
-        submit_bug_comment.retry(exc=e)
+        # Initially retry after 1 minute, then for each subsequent retry
+        # lengthen the retry time by another minute.
+        submit_bug_comment.retry(exc=e, countdown=(1 + submit_bug_comment.request.retries) * 60)
         # this exception will be raised once the number of retries
         # exceeds max_retries
         raise

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -89,7 +89,8 @@ def parse_log(project, job_log_url, job_guid, check_errors=False):
                 'parse_timestamp': current_timestamp
             }
         )
-        # for every retry, set the countdown to 10 minutes
+        # Initially retry after 1 minute, then for each subsequent retry
+        # lengthen the retry time by another minute.
+        parse_log.retry(exc=e, countdown=(1 + parse_log.request.retries) * 60)
         # .retry() raises a RetryTaskError exception,
         # so nothing below this line will be executed.
-        parse_log.retry(exc=e, countdown=10*60)


### PR DESCRIPTION
With this change, the first retry is now after 1 minute, then the time for each subsequent
retry lengthens by a further minute each time.