### PR TITLE
Bug 1121670 - Use search() instead of match() for search term leak regex

### DIFF
--- a/tests/log_parser/test_utils.py
+++ b/tests/log_parser/test_utils.py
@@ -56,10 +56,16 @@ LEAK_LINE_TEST_CASES = (
             '(BackstagePass, CallbackObject, DOMEventTargetHelper, '
             'EventListenerManager, EventTokenBucket, ...)'
         ),
+        'BackstagePass, CallbackObject, DOMEventTargetHelper, EventListenerManager, EventTokenBucket, ...'
+    ),
+    (
         (
-            'BackstagePass, CallbackObject, DOMEventTargetHelper, '
-            'EventListenerManager, EventTokenBucket, ...'
-        )
+            'TEST-UNEXPECTED-FAIL '
+            '| leakcheck | tab process: 44330 bytes leaked '
+            '(AsyncLatencyLogger, AsyncTransactionTrackersHolder, AudioOutputObserver, '
+            'BufferRecycleBin, CipherSuiteChangeObserver, ...)'
+        ),
+        'AsyncLatencyLogger, AsyncTransactionTrackersHolder, AudioOutputObserver, BufferRecycleBin, CipherSui'
     ),
 )
 

--- a/treeherder/log_parser/utils.py
+++ b/treeherder/log_parser/utils.py
@@ -67,7 +67,7 @@ def get_error_search_term(error_line):
 
         # Leak failure messages are of the form:
         # leakcheck | .*leaked \d+ bytes (Object-1, Object-2, Object-3, ...)
-        match = LEAK_RE.match(message)
+        match = LEAK_RE.search(message)
         if match:
             search_term = match.group(1)
         else:


### PR DESCRIPTION
Since we were missing leak failure messages that were prefixed with the process name, eg:
"... | leakcheck | tab process: 42114 bytes leaked (...)"

Using .search() is quicker than using .match() with '.*' prefixed to the regex - see https://bugzilla.mozilla.org/show_bug.cgi?id=1076770#c1