### PR TITLE
Bug 1124842 - Log the server response for Bugzilla/ES submission errors

### DIFF
--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -79,7 +79,11 @@ class OrangeFactorBugRequest(object):
         logger.info("Sending data to %s: %s", es_url, self.body)
         headers = {'Content-Type': 'text/plain', 'Connection': 'close'}
         r = requests.post(es_url, data=json.dumps(self.body), headers=headers)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error("HTTPError %s submitting to %s: %s", r.status_code, es_url, r.text)
+            raise
 
 
 class BugzillaBugRequest(object):
@@ -163,4 +167,8 @@ class BugzillaBugRequest(object):
         headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
         logger.info("Sending data to %s: %s", api_url, self.body)
         r = requests.post(api_url, params=credentials, data=json.dumps(self.body), headers=headers)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error("HTTPError %s submitting to %s: %s", r.status_code, api_url, r.text)
+            raise


### PR DESCRIPTION
Previously we only get the HTTPError code in the exception, without the server response that gives more context. The latter would help explain the 400s in bug 1114785.

Example output with this change:

HTTPError 401 submitting to https://bugzilla.mozilla.org/rest/bug/1078237/comment: {"documentation":"http://www.bugzilla.org/docs/tip/en/html/api/","error":true,"code":410,"message":"You must log in before using this part of Bugzilla."}
Traceback (most recent call last):
  File "C:/Users/Ed/Desktop/requests-foo.py", line 5, in <module>
    r.raise_for_status()
  File "C:\Python27\lib\site-packages\requests\models.py", line 831, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Authorization Required