### PR TITLE
Bug 1126356 - Add support for |manage.py ingest_push <project> tip|

### DIFF
--- a/treeherder/etl/management/commands/ingest_push.py
+++ b/treeherder/etl/management/commands/ingest_push.py
@@ -56,16 +56,19 @@ class Command(BaseCommand):
 
         # ingest this particular revision for this project
         process = HgPushlogProcess()
-        process.run(pushlog_url, project, changeset=changeset)
+        # Use the actual push SHA, in case the changeset specified was a tag
+        # or branch name (eg tip). HgPushlogProcess returns the full SHA, but
+        # job ingestion expects the short version, so we truncate it.
+        push_sha = process.run(pushlog_url, project, changeset=changeset)[0:12]
 
         self._process_all_objects_for_project(project)
 
         Builds4hJobsProcess().run(filter_to_project=project,
-                                  filter_to_revision=changeset)
+                                  filter_to_revision=push_sha)
         PendingJobsProcess().run(filter_to_project=project,
-                                 filter_to_revision=changeset)
+                                 filter_to_revision=push_sha)
         RunningJobsProcess().run(filter_to_project=project,
-                                 filter_to_revision=changeset)
+                                 filter_to_revision=push_sha)
 
         self._process_all_objects_for_project(project)
 

--- a/treeherder/etl/pushlog.py
+++ b/treeherder/etl/pushlog.py
@@ -128,6 +128,10 @@ class HgPushlogProcess(HgPushlogTransformerMixin,
                 # changeset
                 cache.set("{0}:last_push".format(repository), top_revision)
 
+            return top_revision
+
+        return None
+
 
 class MissingHgPushlogProcess(HgPushlogTransformerMixin,
                               OAuthLoaderMixin):


### PR DESCRIPTION
The most recent push from a repository is given the tag 'tip' in Mercurial. To save having to look up a specific revision to ingest when testing, 'tip' can now be passed to ingest_push, and the revision that 'tip' currently maps to, will be used during push and jobs ingestion. Previously, jobs ingestion would have used the non-existent SHA of 'tip' when trying to associate jobs with pushes, resulting in no jobs being imported from builds-{pending,running,4hr}.