### PR TITLE
Bug 1125586 - Enable the 'require_host_type' datasource option

### DIFF
--- a/treeherder/model/derived/refdata.py
+++ b/treeherder/model/derived/refdata.py
@@ -36,6 +36,7 @@ class RefDataManager(object):
                     "user": settings.DATABASES['read_only']['USER'],
                     "passwd": settings.DATABASES['read_only']['PASSWORD']
                 },
+                "require_host_type": True,
                 "default_db": settings.DATABASES['default']['NAME'],
                 "procs": [procs_path]
             }

--- a/treeherder/model/models.py
+++ b/treeherder/model/models.py
@@ -337,6 +337,7 @@ class Datasource(models.Model):
                     "user": settings.TREEHERDER_RO_DATABASE_USER,
                     "passwd": settings.TREEHERDER_RO_DATABASE_PASSWORD,
                 },
+                "require_host_type": True,
                 "default_db": self.name,
                 "procs": [
                     os.path.join(SQL_PATH, procs_file_name),


### PR DESCRIPTION
Uses the new datasource option added by bug 1125585, to enforce that a
host_type is always specified, and thus avoid silently falling back to
the master_host when the read_host might have been more suitable.