### PR TITLE
Bug 1127940 - Simplify BugzillaBugRequest username handling to avoid host DB race

### DIFF
--- a/tests/etl/test_tbpl.py
+++ b/tests/etl/test_tbpl.py
@@ -60,10 +60,7 @@ def test_tbpl_bugzilla_request_body(jm, eleven_jobs_processed):
 
     bug_id = 12345678
     job = jm.get_job_list(0, 1)[0]
-
-    submit_timestamp = int(time())
     who = "user@mozilla.com"
-    jm.insert_bug_job_map(job['id'], bug_id, "manual", submit_timestamp, who)
 
     bug_suggestions = []
     bug_suggestions.append({"search": "First error line", "bugs": []})
@@ -76,7 +73,7 @@ def test_tbpl_bugzilla_request_body(jm, eleven_jobs_processed):
     ]
 
     jm.store_job_artifact([bug_suggestions_placeholders])
-    req = BugzillaBugRequest(jm.project, job["id"], bug_id)
+    req = BugzillaBugRequest(jm.project, job["id"], bug_id, who)
     req.generate_request_body()
 
     expected = {

--- a/tests/model/derived/test_jobs_model.py
+++ b/tests/model/derived/test_jobs_model.py
@@ -482,32 +482,6 @@ def test_ingesting_skip_existing(jm, sample_data, initial_data, refdata,
     assert len(jl) == 2
 
 
-def test_bug_job_map_detail(jm, eleven_jobs_processed):
-    """
-    test retrieving a single bug_job_map row
-    """
-    job_id = jm.get_job_list(0, 1)[0]["id"]
-    bug_id = 123456
-
-    submit_timestamp = int(time.time())
-    who = "user@mozilla.com"
-    try:
-        jm.insert_bug_job_map(job_id, bug_id, "manual", submit_timestamp, who)
-
-        actual = jm.get_bug_job_map_detail(job_id, bug_id)
-    finally:
-        jm.disconnect()
-
-    expected = {
-        "job_id": job_id,
-        "bug_id": bug_id,
-        "type": "manual",
-        "submit_timestamp": submit_timestamp,
-        "who": who}
-
-    assert actual == expected
-
-
 def test_ingest_job_with_updated_job_group(jm, refdata, sample_data, initial_data,
                                   mock_log_parser, result_set_stored):
     """

--- a/treeherder/etl/tasks/tbpl_tasks.py
+++ b/treeherder/etl/tasks/tbpl_tasks.py
@@ -29,13 +29,13 @@ def submit_star_comment(project, job_id, bug_id, submit_timestamp, who):
 
 
 @task(name="submit-bug-comment", max_retries=10, time_limit=30)
-def submit_bug_comment(project, job_id, bug_id):
+def submit_bug_comment(project, job_id, bug_id, who):
     """
     Send a post request to tbpl's submitBugzillaComment.php
     to add a new comment to the associated bug on bugzilla.
     """
     try:
-        req = BugzillaBugRequest(project, job_id, bug_id)
+        req = BugzillaBugRequest(project, job_id, bug_id, who)
         req.generate_request_body()
         req.send_request()
     except Exception, e:

--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -88,10 +88,11 @@ class OrangeFactorBugRequest(object):
 
 class BugzillaBugRequest(object):
 
-    def __init__(self, project, job_id, bug_id):
+    def __init__(self, project, job_id, bug_id, who):
         self.project = project
         self.job_id = job_id
         self.bug_id = bug_id
+        self.who = who
         self.body = ""
 
     def generate_request_body(self):
@@ -111,7 +112,6 @@ class BugzillaBugRequest(object):
                 # a bug suggestion aritfact looks like this:
                 # [{ "search": "my-error-line", "bugs": ....}]
                 error_lines += [line["search"] for line in artifact["blob"]]
-            bug_job_map = jm.get_bug_job_map_detail(self.job_id, self.bug_id)
 
             revision_list = jm.get_resultset_revisions_list(
                 job["result_set_id"]
@@ -124,7 +124,7 @@ class BugzillaBugRequest(object):
         finally:
             jm.disconnect()
 
-        who = bug_job_map["who"]\
+        who = self.who \
             .replace("@", "[at]")\
             .replace(".", "[dot]")
         start_time = datetime.fromtimestamp(job["start_timestamp"]).isoformat()

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -881,22 +881,6 @@ into chunks of chunk_size size. Returns the number of result sets deleted"""
         )
         return data
 
-    def get_bug_job_map_detail(self, job_id, bug_id):
-        """
-        Returns a single instance of bug_job_map.
-        Raises a ObjectNotFoundException when no object is found
-        """
-
-        data = self.jobs_execute(
-            proc="jobs.selects.get_bug_job_map_detail",
-            placeholders=[job_id, bug_id],
-            debug_show=self.DEBUG,
-        )
-        if not data:
-            raise ObjectNotFoundException("bug_jib_map",
-                                          job_id=job_id, bug_id=bug_id)
-        return data[0]
-
     def get_result_set_ids(self, revision_hashes, where_in_list):
         """Return the  a dictionary of revision_hash to id mappings given
            a list of revision_hashes and a where_in_list.

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -628,6 +628,7 @@ class JobsModel(TreeherderModelBase):
                         self.project,
                         job_id,
                         bug_id,
+                        who,
                     ],
                     routing_key='high_priority'
                 )

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -886,12 +886,6 @@
                    REP0",
             "host_type": "read_host"
         },
-        "get_bug_job_map_detail":{
-            "sql":"SELECT `job_id`, `bug_id`, `type`, `submit_timestamp`, `who`
-                   FROM `bug_job_map`
-                   WHERE job_id = ? and bug_id = ?",
-            "host_type": "read_host"
-        },
         "get_resultset_status":{
             "sql":"SELECT
                         id,


### PR DESCRIPTION
We did not previously pass the username of the person who made a failure classification to BugzillaBugRequest. As a result, BugzillaBugRequest has to fetch the bug mapping again to find it out. After the fix for our master-read DB setup, this fetch of the bug mapping was being performed against the read host, which occasionally did not yet have the requested mapping (due to replication delay) causing an ObjectNotFoundException.

The 'get_bug_job_map_detail' query could have been switched to use the master host to avoid the race, however the more efficient fix is just to pass the username to BugzillaBugRequest directly, like we already do for OrangeFactorBugRequest, avoiding the query entirely.

As a result, get_bug_job_map_detail() is then unused, so can be removed.