### PR TITLE
Bug 1097090 - Re-add ref_data_name to jobs endpoints

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -51,7 +51,8 @@ def test_job_list(webapp, eleven_jobs_processed, jm):
         "failure_classification_id",
         "pending_eta",
         "running_eta",
-        "last_modified"
+        "last_modified",
+        "ref_data_name"
     ]
     for job in jobs:
         assert set(job.keys()) == set(exp_keys)

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -547,7 +547,8 @@
                     j.`end_timestamp`,
                     j.`submit_timestamp`,
                     j.`pending_eta`,
-                    j.`running_eta`
+                    j.`running_eta`,
+                    rds.`name` as ref_data_name
                   FROM `job` as j
                   LEFT JOIN `REP0`.`machine` as m
                     ON j.`machine_id` = m.id
@@ -559,6 +560,8 @@
                     ON j.`job_type_id` = jt.id
 				  LEFT JOIN `REP0`.`job_group` as jg
                     ON jt.`job_group_id` = jg.id
+                  LEFT JOIN `REP0`.reference_data_signatures rds
+                    ON j.signature = rds.signature
                   WHERE j.id = ?",
 
             "host_type":"read_host"
@@ -595,7 +598,8 @@
                     j.`submit_timestamp`,
                     j.`pending_eta`,
                     j.`running_eta`,
-                    j.`last_modified`
+                    j.`last_modified`,
+                    rds.`name` as ref_data_name
                   FROM `job` as j
                   LEFT JOIN `REP0`.`machine` as m
                     ON j.`machine_id` = m.id
@@ -609,6 +613,8 @@
                     ON jt.`job_group_id` = jg.id
                   LEFT JOIN `REP0`.`device` as d
                     ON j.device_id = d.id
+                  LEFT JOIN `REP0`.reference_data_signatures rds
+                    ON j.signature = rds.signature
                   WHERE 1
                   REP1",
 


### PR DESCRIPTION
This field is required to filter in the ui by buildername.