### PR TITLE
 Use simplejson instead of json in production code

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -5,7 +5,7 @@
 import logging
 import time
 import datetime
-import json
+import simplejson as json
 import os
 import copy
 

--- a/treeherder/etl/management/commands/export_project_credentials.py
+++ b/treeherder/etl/management/commands/export_project_credentials.py
@@ -3,7 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import json
+import simplejson as json
 
 from optparse import make_option
 from django.core.management.base import BaseCommand

--- a/treeherder/etl/management/commands/import_project_credentials.py
+++ b/treeherder/etl/management/commands/import_project_credentials.py
@@ -3,7 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
-import json
+import simplejson as json
 
 from django.core.management.base import BaseCommand, CommandError
 from treeherder.model.models import Datasource

--- a/treeherder/etl/oauth_utils.py
+++ b/treeherder/etl/oauth_utils.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
+import simplejson as json
 from treeherder import path
 import copy
 import logging

--- a/treeherder/etl/perf_data_adapters.py
+++ b/treeherder/etl/perf_data_adapters.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
-from json import encoder
+import simplejson as json
+from simplejson import encoder
 
 from hashlib import sha1
 import math

--- a/treeherder/etl/pulse.py
+++ b/treeherder/etl/pulse.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
+import simplejson as json
 import time
 import datetime
 import sys

--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 import logging
 
-import json
+import simplejson as json
 import requests
 from treeherder.model.derived import JobsModel
 from django.conf import settings

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
+import simplejson as json
 import MySQLdb
 import time
 import logging

--- a/treeherder/model/management/commands/populate_performance_series.py
+++ b/treeherder/model/management/commands/populate_performance_series.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
+import simplejson as json
 import sys
 
 from optparse import make_option

--- a/treeherder/model/utils.py
+++ b/treeherder/model/utils.py
@@ -3,7 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
 import time
-import json
+import simplejson as json
 import random
 from _mysql_exceptions import OperationalError
 

--- a/treeherder/webapp/api/objectstore.py
+++ b/treeherder/webapp/api/objectstore.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
+import simplejson as json
 
 from rest_framework import viewsets
 from rest_framework.response import Response

--- a/treeherder/webapp/api/projects.py
+++ b/treeherder/webapp/api/projects.py
@@ -4,7 +4,7 @@
 
 from django.http import HttpResponse, HttpResponseNotFound
 from treeherder.model.derived import DatasetNotFoundError
-import json
+import simplejson as json
 
 from treeherder.model.derived import JobsModel
 


### PR DESCRIPTION
For a large set of series, we can wind up processing a fair bit of json.
Each time isn't huge (0.07s on my laptop for the biggest series over 90 days),
but in aggregate (e.g. 51 series in tp5 * 5 time series) that could add up.
simplejson is nearly 10 times (0.009s for the same series) and we already have
it installed, so let's just use it. ujson is slightly faster still (0.006s)
but it's not installed.