### PR TITLE
Bug 1114785 - Limit the total length of comments submitted to Bugzilla

### DIFF
--- a/treeherder/etl/tbpl.py
+++ b/treeherder/etl/tbpl.py
@@ -144,6 +144,12 @@ class BugzillaBugRequest(object):
         body_comment += '\n\n'
         body_comment += '\n'.join(error_lines)
 
+        # Truncate the comment to ensure it is not rejected for exceeding the max
+        # Bugzilla comment length and to reduce the amount of spam in bugs. We should
+        # rarely hit this given the number of error lines are capped during ingestion.
+        if len(body_comment) > settings.BZ_MAX_COMMENT_LENGTH:
+            body_comment = body_comment[:settings.BZ_MAX_COMMENT_LENGTH - 3] + '...'
+
         self.body = {
             "comment": body_comment
         }

--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -333,6 +333,11 @@ ES_HOST = "http://elasticsearch-zlb.webapp.scl3.mozilla.com:9200"
 TBPLBOT_EMAIL = os.environ.get("TBPLBOT_EMAIL", "")
 TBPLBOT_PASSWORD = os.environ.get("TBPLBOT_PASSWORD", "")
 
+# Bugzilla comments cannot be longer than 65535 characters, so we must ensure the
+# comment length does not exceed this, or the comment will be rejected. We truncate
+# to a length lower than the real limit, to reduce the amount of spam in bugs.
+BZ_MAX_COMMENT_LENGTH = 40000
+
 # timeout for requests to external sources
 # like ftp.mozilla.org or hg.mozilla.org
 TREEHERDER_REQUESTS_TIMEOUT = 30


### PR DESCRIPTION
Bugzilla comments can be no more than 65535 characters in length. To
both avoid hitting this limit (and the comment being rejected) and to
reduce the spam left on bugs, truncate the comment body at 40000
characters.