### PR TITLE
Pull request to add Bugzilla and BMO to treeherder UI for CI testing

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -763,6 +763,7 @@
         "active_status": "active",
         "codebase": "taskcluster",
         "repository_group": 4,
+        "description": "A suite of tests to check the quality of the BMO codebase."
     }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -739,5 +739,31 @@
         "repository_group": 2,
         "description": ""
     }
+},
+{
+    "pk": 61,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "Bugzilla"
+        "url": "https://github.com/bugzilla/bugzilla",
+        "active_status": "active",
+        "codebase": "taskcluster",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the Bugzilla codebase."
+    }
+},
+{
+    "pk": 62,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "BMO"
+        "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
+        "active_status": "active",
+        "codebase": "taskcluster",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the BMO codebase."
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -739,5 +739,30 @@
         "repository_group": 2,
         "description": ""
     }
+},
+{
+    "pk": 61,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "Bugzilla",
+        "url": "https://github.com/bugzilla/bugzilla",
+        "active_status": "active",
+        "codebase": "taskcluster",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the Bugzilla codebase."
+    }
+},
+{
+    "pk": 62,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "BMO",
+        "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
+        "active_status": "active",
+        "codebase": "taskcluster",
+        "repository_group": 4,
+    }
 }
 ]

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -748,7 +748,7 @@
         "name": "Bugzilla",
         "url": "https://github.com/bugzilla/bugzilla",
         "active_status": "active",
-        "codebase": "taskcluster",
+        "codebase": "bugzilla",
         "repository_group": 4,
         "description": "A suite of tests to check the quality of the Bugzilla codebase."
     }
@@ -761,7 +761,7 @@
         "name": "BMO",
         "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
         "active_status": "active",
-        "codebase": "taskcluster",
+        "codebase": "bugzilla",
         "repository_group": 4,
         "description": "A suite of tests to check the quality of the BMO codebase."
     }

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -745,7 +745,7 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "git",
-        "name": "Bugzilla",
+        "name": "bugzilla",
         "url": "https://github.com/bugzilla/bugzilla",
         "active_status": "active",
         "codebase": "bugzilla",
@@ -758,7 +758,7 @@
     "model": "model.repository",
     "fields": {
         "dvcs_type": "git",
-        "name": "BMO",
+        "name": "bmo",
         "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
         "active_status": "active",
         "codebase": "bugzilla",

--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -739,31 +739,5 @@
         "repository_group": 2,
         "description": ""
     }
-},
-{
-    "pk": 61,
-    "model": "model.repository",
-    "fields": {
-        "dvcs_type": "git",
-        "name": "Bugzilla"
-        "url": "https://github.com/bugzilla/bugzilla",
-        "active_status": "active",
-        "codebase": "taskcluster",
-        "repository_group": 4,
-        "description": "A suite of tests to check the quality of the Bugzilla codebase."
-    }
-},
-{
-    "pk": 62,
-    "model": "model.repository",
-    "fields": {
-        "dvcs_type": "git",
-        "name": "BMO"
-        "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
-        "active_status": "active",
-        "codebase": "taskcluster",
-        "repository_group": 4,
-        "description": "A suite of tests to check the quality of the BMO codebase."
-    }
 }
 ]


### PR DESCRIPTION
In the near future, we want to switch off of Travis CI and use the new TaskCluster system for performing CI testing for upstream Bugzilla and also BMO (bugzilla.mozilla.org). To see the test results from the TaskCluster jobs, we would like to be able to feed the results into TreeHerder. Please advise if more than what is here is needed to make this a possibility.

Thanks
dkl@mozilla.com