### PR TITLE
Add support for the Bugzilla and BMO projects

### DIFF
--- a/treeherder/model/fixtures/repository.json
+++ b/treeherder/model/fixtures/repository.json
@@ -739,5 +739,31 @@
         "repository_group": 2,
         "description": ""
     }
+},
+{
+    "pk": 61,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "bugzilla",
+        "url": "https://github.com/bugzilla/bugzilla",
+        "active_status": "active",
+        "codebase": "bugzilla",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the Bugzilla codebase."
+    }
+},
+{
+    "pk": 62,
+    "model": "model.repository",
+    "fields": {
+        "dvcs_type": "git",
+        "name": "bmo",
+        "url": "https://github.com/mozilla/webtools-bmo-bugzilla",
+        "active_status": "active",
+        "codebase": "bugzilla",
+        "repository_group": 4,
+        "description": "A suite of tests to check the quality of the BMO codebase."
+    }
 }
 ]


### PR DESCRIPTION
In the near future, we want to switch off of Travis CI and use the new TaskCluster system for performing CI testing for upstream Bugzilla and also BMO (bugzilla.mozilla.org). To see the test results from the TaskCluster jobs, we would like to be able to feed the results into TreeHerder. Please advise if more than what is here is needed to make this a possibility.

Thanks
dkl@mozilla.com
