### PR TITLE
Bug 1131133 - group jobs by id

### DIFF
--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -562,7 +562,8 @@
                     ON jt.`job_group_id` = jg.id
                   LEFT JOIN `REP0`.reference_data_signatures rds
                     ON j.signature = rds.signature
-                  WHERE j.id = ?",
+                  WHERE j.id = ?
+                  GROUP BY j.id",
 
             "host_type":"read_host"
         },
@@ -616,7 +617,9 @@
                   LEFT JOIN `REP0`.reference_data_signatures rds
                     ON j.signature = rds.signature
                   WHERE 1
-                  REP1",
+                  REP1
+                  GROUP BY j.id
+                  ",
 
             "host_type":"read_host"
         },


### PR DESCRIPTION
This is a quick&dirty solution to circumvent the problem of the duplicate signatures.
The buildername is selected randomly by the group by, but that's more or
less what we have done until now so we can probably keep living with that.