### PR TITLE
Bug 1133362 - Update flake8/pep8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,13 @@
 [pep8]
 exclude = .git,__pycache__,.vagrant,build,vendor
-# E501 line too long
-# F403 'from module import *' used; unable to detect undefined names
-ignore = E501,F403
+# E121,E123,E126,E226,E24,E704: Ignored in default pep8 config:
+# https://github.com/jcrocholl/pep8/blob/8ca030e2d8f6d377631bae69a18307fb2d051049/pep8.py#L68
+# Our additions...
+# E501: line too long
+ignore = E121,E123,E126,E226,E24,E704,E501
 
 [flake8]
 exclude = .git,__pycache__,.vagrant,build,vendor
-# E501 line too long
-# F403 'from module import *' used; unable to detect undefined names
-ignore = E501,F403
+# The ignore list for pep8 above, plus our own PyFlakes addition:
+# F403: 'from module import *' used; unable to detect undefined names
+ignore = E121,E123,E126,E226,E24,E704,E501,F403

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,9 @@ exclude = .git,__pycache__,.vagrant,build,vendor
 ignore = E121,E123,E126,E226,E24,E704,E501
 
 [flake8]
+# flake8 is a combination of pyflakes & pep8.
+# Unfortunately we have to mostly duplicate the above, since some tools use
+# pep8's config (eg autopep8) so we can't just define everything under [flake8].
 exclude = .git,__pycache__,.vagrant,build,vendor
 # The ignore list for pep8 above, plus our own PyFlakes addition:
 # F403: 'from module import *' used; unable to detect undefined names

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [pep8]
-exclude = .git,.vagrant,build,vendor
+exclude = .git,__pycache__,.vagrant,build,vendor
 # E501 line too long
 # F403 'from module import *' used; unable to detect undefined names
 ignore = E501,F403
 
 [flake8]
-exclude = .git,.vagrant,build,vendor
+exclude = .git,__pycache__,.vagrant,build,vendor
 # E501 line too long
 # F403 'from module import *' used; unable to detect undefined names
 ignore = E501,F403


### PR DESCRIPTION
* Add ```__pycache__``` to ```exclude```. It's in the default exclude list for pep8, and we clobber this by setting our own.
* Ignore error types that pep8 does by default. Defining ```ignore``` ourselves overwrites the default ignore list. This adds in the current pep8 ignore list, to ensure we don't re-enable noisy error types inadvertently.
* Add explanation for the duplicated config.