### PR TITLE
Revert bug 1093743 due to builds-4hr inconsistencies causing orphaned running jobs

### DIFF
--- a/treeherder/etl/buildapi.py
+++ b/treeherder/etl/buildapi.py
@@ -44,6 +44,14 @@ class Builds4hTransformerMixin(object):
                 prop["branch"], build))
             raise e
 
+        try:
+            request_times = build['properties'].get('request_times',
+                                                    build['requesttime'])
+        except KeyError as e:
+            logger.error("({0})request_time not found in {1}".format(
+                prop["branch"], build))
+            raise e
+
         endtime = None
         if buildbot.RESULT_DICT[build['result']] == 'retry':
             try:
@@ -54,20 +62,7 @@ class Builds4hTransformerMixin(object):
                 raise e
 
         request_id = request_ids[-1]
-
-        # build['properties']['request_times'] is sometimes missing,
-        # so we have to fall back to the top level requesttime property,
-        # even though it doesn't always correspond to the request_id.
-        request_times = prop.get('request_times')
-        if request_times:
-            request_time = request_times[str(request_id)]
-        else:
-            try:
-                request_time = build['requesttime']
-            except KeyError as e:
-                logger.error("({0})request_time not found in {1}".format(
-                    prop["branch"], build))
-                raise e
+        request_time = request_times[str(request_id)]
 
         job_guid_data = {'job_guid': '', 'coalesced': []}
 


### PR DESCRIPTION
Unfortunately whilst the changes in bug 1093743 were slightly more correct than the previous approach, due to inconsistencies in builds-4hr, we're seeing some issues with running jobs being orphaned/duplicated. 

For now, I think it's best to revert PR #359 (and its followup PR #381) so we can deploy the other changes in the meantime.

For more info, see https://bugzilla.mozilla.org/show_bug.cgi?id=1133455#c8 onwards.