### PR TITLE
Bug 1125585 - Update datasource to 2f09c9cc87

### DIFF
--- a/requirements/pure.txt
+++ b/requirements/pure.txt
@@ -26,7 +26,7 @@ httplib2==0.7.4
 
 jsonfield==0.9.20
 
-git+git://github.com/jeads/datasource@fab643e0d5
+git+git://github.com/jeads/datasource@2f09c9cc87
 git+git://github.com/mozilla/treeherder-client@be6cb763dc
 git+git://github.com/Julian/jsonschema@1976689051
 


### PR DESCRIPTION
To pick up the version number bump. This doesn't change the contents of vendor/datasource/ so in theory shouldn't be necessary. However prod pip installs the requirements in pure.txt when it shouldn't, and the vendor directory is later in python.path than site-packages, so we end up using the version installed globally. Unfortunately some of the nodes have an older version of datasource installed, but without the version bump it's hard to tell which.

https://github.com/jeads/datasource/compare/fab643e0d5...2f09c9cc87