### PR TITLE
Bug 1134740 - Use vendor packages in preference to globally installed

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -9,8 +9,8 @@ from datetime import timedelta
 from treeherder import path
 
 # Insure the vendor libraries are added to the python path
-# in production
-sys.path.append(path('..', 'vendor'))
+# in production, and before the site-packages entry.
+sys.path.insert(1, path('..', 'vendor'))
 
 
 # These settings can all be optionally set via env vars, or in local.py:


### PR DESCRIPTION
There is currently duplication between the packages in vendor/ and those
globally installed on stage/production. This change ensures we use those
in vendor/ in preference to those in site-packages & so are using the
version we expected.