### PR TITLE
Bug 1134804 - Only run cycle-data against active repositories

### DIFF
--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
         self.debug("cycle interval: {0}".format(cycle_interval))
 
         projects = Datasource.objects\
-            .filter(contenttype='jobs')\
+            .filter(contenttype='jobs', active_status='active')\
             .values_list('project', flat=True)
         for project in projects:
             self.debug("Cycling Database: {0}".format(project))


### PR DESCRIPTION
init_datasources only creates repositories that have an active_status of 'active'. This means that if an environment was set up after a repository was marked as in-active, the databases for it will not exist
and so cause exceptions when we attempt to run data cycling against them. Bug 1035294 will take care of removing the unused databases, so we should just exclude them from the standard data-cycling.