### PR TITLE
Bug 1135117 - Minor tweaks to readthedocs vagrant setup for clarity

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ Setting up Vagrant
 
 * Install Virtualbox_ and Vagrant_ if not present.
 
-* Either follow the :doc:`ui_integration` steps, or comment out this line in the Vagrantfile:
+* Either follow the :doc:`ui_integration` steps (the most common setup) to develop both the service and the ui together, or to develop only the service comment out this line in the Vagrantfile:
 
   .. code-block:: ruby
 

--- a/docs/ui_integration.rst
+++ b/docs/ui_integration.rst
@@ -1,7 +1,7 @@
 Integrating the ui
 ==================
 
-If you want to develop both the ui and the service side by side it may be convenient to load the ui in the vagrant environment.
+If you want to develop both the ui and the service side by side it may be convenient to load the ui from the vagrant environment.
 
 * Make sure the `treeherder-ui repo`_ is cloned in the same parent folder as treeherder-service (and with the directory name 'treeherder-ui').
 


### PR DESCRIPTION
This tweak addresses bug [1135117](https://bugzilla.mozilla.org/show_bug.cgi?id=1135117).

Nothing major, it just hopefully explains what each of the two configurations mean, why they would choose to do either of them, and hinting at the one which is most common.

As a newbie I found that phrase 'in' in the integrating the ui doc confusing, but maybe it's just me. :) To me it sort of implied I'd be running the browser directly within a VM.