### PR TITLE
Bug 1134916 - Make jobs API return jobs sorted by push_timestamp again

### DIFF
--- a/tests/etl/test_tbpl.py
+++ b/tests/etl/test_tbpl.py
@@ -15,21 +15,21 @@ def test_tbpl_bug_request_body(jm, eleven_jobs_processed):
     Test the request body is created correctly
     """
     bug_id = 12345678
-    job = jm.get_job_list(0, 1)[0]
+    job_id = 1
     sample_artifact = {
         "build_id": 39953854,
         "buildername": "b2g_emulator_vm mozilla-inbound opt test crashtest-2"
     }
     placeholders = [
-        [job["id"], "buildapi", "json",
-         json.dumps(sample_artifact), job["id"], "buildapi"]
+        [job_id, "buildapi", "json",
+         json.dumps(sample_artifact), job_id, "buildapi"]
     ]
     jm.store_job_artifact(placeholders)
 
     submit_timestamp = int(time())
     who = "user@mozilla.com"
 
-    req = OrangeFactorBugRequest(jm.project, job["id"],
+    req = OrangeFactorBugRequest(jm.project, job_id,
                                  bug_id, submit_timestamp, who)
     req.generate_request_body()
 
@@ -58,7 +58,7 @@ def test_tbpl_bugzilla_request_body(jm, eleven_jobs_processed):
     Test the request body is created correctly
     """
     bug_id = 12345678
-    job = jm.get_job_list(0, 1)[0]
+    job_id = 1
     who = "user@mozilla.com"
 
     bug_suggestions = []
@@ -66,13 +66,13 @@ def test_tbpl_bugzilla_request_body(jm, eleven_jobs_processed):
     bug_suggestions.append({"search": "Second error line", "bugs": []})
 
     bug_suggestions_placeholders = [
-        job['id'], 'Bug suggestions',
+        job_id, 'Bug suggestions',
         'json', json.dumps(bug_suggestions),
-        job['id'], 'Bug suggestions',
+        job_id, 'Bug suggestions',
     ]
 
     jm.store_job_artifact([bug_suggestions_placeholders])
-    req = BugzillaBugRequest(jm.project, job["id"], bug_id, who)
+    req = BugzillaBugRequest(jm.project, job_id, bug_id, who)
     req.generate_request_body()
 
     expected = {
@@ -94,7 +94,7 @@ def test_tbpl_bugzilla_comment_length_capped(jm, eleven_jobs_processed):
     Test that the total number of characters in the comment is capped correctly.
     """
     bug_id = 12345678
-    job = jm.get_job_list(0, 1)[0]
+    job_id = 1
     who = "user@mozilla.com"
 
     # Create an error line with length equal to the max comment length.
@@ -103,13 +103,13 @@ def test_tbpl_bugzilla_comment_length_capped(jm, eleven_jobs_processed):
     bug_suggestions = [{"search": "a" * settings.BZ_MAX_COMMENT_LENGTH, "bugs": []}]
 
     bug_suggestions_placeholders = [
-        job['id'], 'Bug suggestions',
+        job_id, 'Bug suggestions',
         'json', json.dumps(bug_suggestions),
-        job['id'], 'Bug suggestions',
+        job_id, 'Bug suggestions',
     ]
 
     jm.store_job_artifact([bug_suggestions_placeholders])
-    req = BugzillaBugRequest(jm.project, job["id"], bug_id, who)
+    req = BugzillaBugRequest(jm.project, job_id, bug_id, who)
     req.generate_request_body()
 
     assert len(req.body['comment']) == settings.BZ_MAX_COMMENT_LENGTH

--- a/tests/webapp/api/test_bug_job_map_api.py
+++ b/tests/webapp/api/test_bug_job_map_api.py
@@ -133,8 +133,8 @@ def test_bug_job_map_list(webapp, jm, eleven_jobs_processed):
     resp = webapp.get(
         reverse("bug-job-map-list", kwargs={"project": jm.project}))
 
-    for i, v in enumerate(expected):
-        assert v == resp.json[i]
+    # The order of the bug-job-map list is not guaranteed.
+    assert sorted(resp.json) == sorted(expected)
 
     jm.disconnect()
 

--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -60,6 +60,11 @@ def test_job_list(webapp, eleven_jobs_processed, jm):
     for job in jobs:
         assert set(job.keys()) == set(exp_keys)
 
+    # The jobs should be returned in order of descending order
+    # of their resultset's push_timestamp, so in this case the
+    # first job should have id of 10.
+    assert jobs[0]['id'] == 10
+
 
 def test_job_list_bad_project(webapp, eleven_jobs_processed, jm):
     """

--- a/tests/webapp/api/test_note_api.py
+++ b/tests/webapp/api/test_note_api.py
@@ -148,13 +148,13 @@ def test_create_note(webapp, eleven_jobs_processed, mock_message_broker, jm):
     assert resp.status_code == 200
 
     content = json.loads(resp.content)
-    assert content['message'] == 'note stored for job 1'
+    assert content['message'] == 'note stored for job %s' % job["id"]
 
     note_list = jm.get_job_note_list(job_id=job["id"])
     del(note_list[0]["note_timestamp"])
 
     assert note_list[0] == {
-        u'job_id': 1L,
+        u'job_id': job["id"],
         u'who': u'foo@bar.com',
         u'failure_classification_id': 2L,
         u'note': u'you look like a man-o-lantern',

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -612,6 +612,8 @@
                     ON j.`job_type_id` = jt.id
 				  LEFT JOIN `REP0`.`job_group` as jg
                     ON jt.`job_group_id` = jg.id
+                  LEFT JOIN result_set rs
+                    ON rs.id = j.result_set_id
                   LEFT JOIN `REP0`.`device` as d
                     ON j.device_id = d.id
                   LEFT JOIN `REP0`.reference_data_signatures rds
@@ -619,6 +621,8 @@
                   WHERE 1
                   REP1
                   GROUP BY j.id
+                  ORDER BY
+                    rs.push_timestamp DESC
                   ",
 
             "host_type":"read_host"


### PR DESCRIPTION
Bug 1097090 combined get_job_list and get_job_list_full, but the two queries were actually subtly different. The former had an ORDER BY push_timestamp, which was lost when they were combined. This means jobs displayed in the similar jobs panel are from the past, and not the most recent jobs of the same type.

The get_job_list query also sorted on platform, however I don't believe this is necessary, so I've not added it back in here. Please do double check though! :-)

Unfortunately we also had tests that were not aimed at the jobs API that were dependant on the
order of jobs returned by get_job_list(). The second commit fixes these:
* test_tbpl.py does not even need to use get_job_list() since the only accessed property is the job_id, which we are better off hard-coding.
* test_note_apy.py should use the job_id found earlier in the test, rather than hard-coding a wrong value.
* In test_bug_job_map_api.py, there is no ORDER BY clause for the stored get_bug_job_map_list query. The current test only happens to pass since the bug_job_map table currently uses the InnoDB engine, which default to the order of the primary key. Were our test environment and production bug_job_map tables to use different engines, the behaviour would silently change, so it seems wrong for the test to give the illusion of a guaranteed order. If in the future we wanted to give such a guarantee, we should add an ORDER BY to the get_bug_job_map_list query & update the test accordingly.