### PR TITLE
Bug 1137162 - Allow spaces in TinderboxPrint link titles

### DIFF
--- a/tests/log_parser/test_tinderbox_print_parser.py
+++ b/tests/log_parser/test_tinderbox_print_parser.py
@@ -109,10 +109,9 @@ TINDERBOX_TEST_CASES = (
                 '2153/<em class="testfail">1</em>&nbsp;'
                 '<em class="testfail">CRASH</em>'
             )
-
         }]
-
     ),
+
     (
         (
             'TinderboxPrint: TalosResult: '
@@ -166,7 +165,22 @@ TINDERBOX_TEST_CASES = (
                 }
             }
         }]
+    ),
 
+    (
+        (
+            'TinderboxPrint: hazard results: '
+            'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
+            'mozilla-central-linux64-br-haz/20150226025813'
+        ),
+        [{
+            'content_type': 'link',
+            'title': 'hazard results',
+            'url': 'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
+                   'mozilla-central-linux64-br-haz/20150226025813',
+            'value': 'https://ftp-ssl.mozilla.org/pub/mozilla.org/firefox/tinderbox-builds/'
+                     'mozilla-central-linux64-br-haz/20150226025813'
+        }]
     ),
 )
 

--- a/treeherder/log_parser/parsers.pyx
+++ b/treeherder/log_parser/parsers.pyx
@@ -201,11 +201,11 @@ RE_UPLOADED_TO = re.compile(
     r"<a href=['\"](?P<url>http(s)?://.*)['\"]>(?P<value>.+)</a>: uploaded"
 )
 RE_LINK_HTML = re.compile(
-    (r"((?P<title>[A-Za-z/\.0-9\-_]+): )?"
+    (r"((?P<title>[A-Za-z/\.0-9\-_ ]+): )?"
      r"<a .*href=['\"](?P<url>http(s)?://.+)['\"].*>(?P<value>.+)</a>")
 )
 RE_LINK_TEXT = re.compile(
-    r"((?P<title>[A-Za-z/\.0-9\-_]+): )?(?P<url>http(s)?://.*)"
+    r"((?P<title>[A-Za-z/\.0-9\-_ ]+): )?(?P<url>http(s)?://.*)"
 )
 
 TINDERBOX_REGEXP_TUPLE = (


### PR DESCRIPTION
Currently if a TinderboxPrint line contains a space in the link title,
eg in 'hazard results' here:
TinderboxPrint: hazard results: https://ftp-ssl.mozilla.org/...
...then we ingest it as content_type 'raw_html' rather than 'link'.