### PR TITLE
Ensure gunicon is pid 1 in docker scripts

### DIFF
--- a/docker/gunicorn.sh
+++ b/docker/gunicorn.sh
@@ -1,7 +1,9 @@
 #! /bin/bash -ex
 source /etc/profile.d/treeherder.sh
 ./docker/generate_test_credentials.py
-gunicorn \
+
+# Use exec so pid 1 is now gunicon instead of bash...
+exec gunicorn \
   -w 5 \
   -b 0.0.0.0:8000 \
   --timeout 120 \


### PR DESCRIPTION
This ensures operations like |docker restart| send signials to gunicorn which
will handle them correctly (where as previously bash would just ignore them)