### PR TITLE
Bug 1138400 - Disable pulse publishing due to Python 2.7.9 incompatibility

### DIFF
--- a/treeherder/settings/base.py
+++ b/treeherder/settings/base.py
@@ -364,6 +364,10 @@ try:
 except ImportError:
     pass
 
+# Override the local config to disable pulse publishing.
+# Remove me when bug 1138400 is fixed.
+PULSE_EXCHANGE_NAMESPACE = None
+
 INSTALLED_APPS += LOCAL_APPS
 
 TEMPLATE_DEBUG = DEBUG


### PR DESCRIPTION
There's a bug with gevent and Python 2.7.9 which the pulse publisher hits.
Disable it until a workaround is found.