### PR TITLE
Bug 1130355 - Data cycling: Reduce chunk size to avoid timeouts/alerts

### DIFF
--- a/treeherder/model/management/commands/cycle_data.py
+++ b/treeherder/model/management/commands/cycle_data.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
             '--chunk-size',
             action='store',
             dest='chunk_size',
-            default=100,
+            default=10,
             type='int',
             help=('Define the size of the chunks '
                   'the target data will be divided in')),


### PR DESCRIPTION
The current chunk size of 100 translates to 100 pushes, which can be as many as 40,000 jobs, which can result in deletes of 100,000+ rows at a time from the artifact tables. This blocks other DB activity & also means the cycle-data task sometimes hits:
OperationalError: (2006, 'MySQL server has gone away')