### PR TITLE
Bug 1138902 - Adjust linter configs

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -2,9 +2,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+test-warnings: true
+strictness: medium
+max-line-length: 140
 uses:
     - django
     - celery
+requirements:
+    - requirements/compiled.txt
+    - requirements/dev.txt
 ignore-paths:
-    - docs
     - vendor
+
+# We run flake8 (pep8 + pyflakes) as part of the Travis run,
+# so it's unnecessary to run them again here.
+pep8:
+  run: false
+pyflakes:
+  run: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ exclude = .git,__pycache__,.vagrant,build,vendor
 # Our additions...
 # E501: line too long
 ignore = E121,E123,E126,E226,E24,E704,E501
+max-line-length = 140
 
 [flake8]
 # flake8 is a combination of pyflakes & pep8.
@@ -14,3 +15,4 @@ exclude = .git,__pycache__,.vagrant,build,vendor
 # The ignore list for pep8 above, plus our own PyFlakes addition:
 # F403: 'from module import *' used; unable to detect undefined names
 ignore = E121,E123,E126,E226,E24,E704,E501,F403
+max-line-length = 140


### PR DESCRIPTION
* Turn on warnings in test code.
* Set strictness explicitly to medium, since it's currently at 'None'.
* Explicitly set the list of requirements files, since otherwise unnecessary packages will be installed, slowing down the landscape.io run.
* Disable pep8/pyflakes, since they are already run as part of the Travis job.