### PR TITLE
Bug 1107523 - Run flake8 as part of the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
   - python setup.py build_ext --inplace
   - mysql -e 'create database treeherder;'
 script:
+  - flake8 --show-source
   - py.test tests/$* --runslow
 notifications:
   email: false

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,3 +22,5 @@ virtualenv==1.7.1.2
 
 #for celery auto-reloading
 pyinotify==0.9.4
+
+flake8


### PR DESCRIPTION
In a later PR I'll add docs for setting up locally & also how to set up as a git commit hook locally to avoid frustration by people forgetting to run flake8 before pushing to a PR branch. However for now I'm just keen to get this running so we don't regress things, now that I have all errors/warnings fixed.

Few notes:
* flake8 is pyflakes+pep8.
* Errors will cause the entire job to report as a failure, however the whole job will still run (including our existing tests).
* flake8 will use setup.cfg that I've already set up - happy to add/tweak which warnings it ignores if we find some to be too noisy in the future.