### PR TITLE
Bug 1137278 - Travis: Cache the .cache/pip/ directory explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ sudo: false
 language: python
 python:
   - "2.7"
-cache: pip
+cache:
+  directories:
+    - $HOME/.cache/pip
 env:
   global:
     - DB=mysql


### PR DESCRIPTION
Travis |cache: pip| should do this for us, except it only works if we don't set our own install step, due to:
https://github.com/travis-ci/travis-ci/issues/3239

Instead, let's manually specify the directory to cache.