### PR TITLE
Bug 1137278 - Travis: Re-use the virtualenv rather than the pip cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "2.7"
 cache:
   directories:
-    - $HOME/.cache/pip
+    - $HOME/virtualenv/python2.7.9
 env:
   global:
     - DB=mysql


### PR DESCRIPTION
Whilst making Travis store the pip cache saves us from having to download the packages from PyPI each time, the vast majority of time spent during Travis run setup is compiling the packages that contain binary components. As such, let's try caching the virtualenv itself so we don't have to repeat this each time. We no longer get Travis to store the pip cache since it will only be used when the virtualenv is first created & will bloat the Travis cache archive that has to be downloaded from AWS at the start of each run.