### PR TITLE
Flake8 improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ install:
   - pip install -r requirements/common.txt
   - pip install -r requirements/dev.txt
 before_script:
+  - flake8 --show-source
   - python setup.py build_ext --inplace
   - mysql -e 'create database treeherder;'
 script:
-  - flake8 --show-source
   - py.test tests/$* --runslow
 notifications:
   email:

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -18,6 +18,33 @@ In order to make the various services aware of a change in the code you need to 
 
    > sudo /etc/init.d/supervisord restart
 
+.. _running-tests:
+
+Running the tests
+-----------------
+
+* You can run the py.test suite with
+
+  .. code-block:: bash
+
+     (venv)vagrant@precise32:~/treeherder-service$ ./runtests.sh
+
+* Or for more control, run py.test directly
+
+  .. code-block:: bash
+
+     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/
+     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/log_parser/test_utils.py
+     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/etl/test_buildapi.py -k test_ingest_builds4h_jobs
+
+* To run all tests, including slow tests that are normally skipped, use
+
+  .. code-block:: bash
+
+     (venv)vagrant@precise32:~/treeherder-service$ py.test --runslow tests/
+
+* For more options, see ``py.test --help`` or http://pytest.org/latest/usage.html
+
 Add a new repository
 --------------------
 

--- a/docs/common_tasks.rst
+++ b/docs/common_tasks.rst
@@ -23,7 +23,7 @@ In order to make the various services aware of a change in the code you need to 
 Running the tests
 -----------------
 
-* You can run the py.test suite with
+* You can run flake8 and the py.test suite using
 
   .. code-block:: bash
 
@@ -44,6 +44,12 @@ Running the tests
      (venv)vagrant@precise32:~/treeherder-service$ py.test --runslow tests/
 
 * For more options, see ``py.test --help`` or http://pytest.org/latest/usage.html
+
+* To run flake8 on its own, use
+
+  .. code-block:: bash
+
+     (venv)vagrant@precise32:~/treeherder-service$ flake8
 
 Add a new repository
 --------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,32 +52,7 @@ Setting up Vagrant
 
   NB: If you change something in the treeherder/log_parser folder, remember to repeat this step, otherwise the changes will not take effect.
 
-Running the tests
------------------
-
-* The tests can be run without following the local instance steps below.
-
-* You can run the py.test suite with
-
-  .. code-block:: bash
-
-     (venv)vagrant@precise32:~/treeherder-service$ ./runtests.sh
-
-* Or for more control, run py.test directly
-
-  .. code-block:: bash
-
-     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/
-     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/log_parser/test_utils.py
-     (venv)vagrant@precise32:~/treeherder-service$ py.test tests/etl/test_buildapi.py -k test_ingest_builds4h_jobs
-
-* To run all tests, including slow tests that are normally skipped, use
-
-  .. code-block:: bash
-
-     (venv)vagrant@precise32:~/treeherder-service$ py.test --runslow tests/
-
-* For more options, see ``py.test --help`` or http://pytest.org/latest/usage.html
+* If you just wish to :ref:`run the tests <running-tests>`, you can stop now without performing the remaining steps below.
 
 Setting up a local Treeherder instance
 --------------------------------------

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 
+echo "Running flake8"
+flake8 || { echo "flake8 errors found!"; exit 1; }
+
+echo "Running Python tests"
 py.test tests/$* --cov-report html --cov treeherder


### PR DESCRIPTION
* Bug 1143086 - Travis: Run flake8 first & end the job early if it fails. Steps in before_script (and any other part of the build lifecycle apart from 'script') terminate the run immediately on failure. This means in the case of flake8 failures, the job changes from "in progress" to "errored" virtually immediately (with the virtualenv caching changes) so the user can see the problem and re-push straight away. See: http://docs.travis-ci.com/user/build-lifecycle/
* Bug 1139894 - Add flake8 to runtests.sh. flake8 is run on Travis, so let's make it harder to forget to run locally for people who use runtests.sh. Eventually we should move all of this to setup.py.
* Bug 1139894 - Docs: Move the "Running the tests" section to common tasks. At some point in the future, we may break the "Running the tests" section out to its own file, but for now "Common Tasks" seems like a better home than the installation instructions.
* Bug 1139894 - Docs: Add instructions for how to run flake8
