### PR TITLE
Bug 1144805 - Vagrant: Show command output for errors during provision

### DIFF
--- a/puppet/manifests/vagrant.pp
+++ b/puppet/manifests/vagrant.pp
@@ -26,8 +26,11 @@ $RABBITMQ_VHOST = 'treeherder'
 $RABBITMQ_HOST = 'localhost'
 $RABBITMQ_PORT = '5672'
 
+# We need to force output on_failure, since we're using Puppet 2.x which
+# does not have the fix for https://projects.puppetlabs.com/issues/10907
 Exec {
     path => "/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin",
+    logoutput => on_failure,
 }
 
 line {"etc-hosts":


### PR DESCRIPTION
We need to force output on_failure, since we're using Puppet 2.x which does not have the fix for https://projects.puppetlabs.com/issues/10907