### PR TITLE
Bug 1144916 - Vagrant: Use latest pip/setuptools/virtualenv

### DIFF
--- a/puppet/manifests/classes/dev.pp
+++ b/puppet/manifests/classes/dev.pp
@@ -6,7 +6,7 @@ class dev{
   exec{"pip-install-dev":
     user => "${APP_USER}",
     cwd => '/tmp',
-    command => "${VENV_DIR}/bin/pip install --download-cache=/home/${APP_USER}/pip_cache -r ${PROJ_DIR}/requirements/dev.txt",
+    command => "${VENV_DIR}/bin/pip install -r ${PROJ_DIR}/requirements/dev.txt",
     timeout => 1800,
   }
 

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -65,20 +65,11 @@ class python {
   }
 
   exec{"pip-install-compiled":
-    require => [
-      Exec['create-virtualenv'],
-      File[ "/home/${APP_USER}/pip_cache"],
-    ],
+    require => Exec['create-virtualenv'],
     user => "${APP_USER}",
     cwd => '/tmp',
-    command => "${VENV_DIR}/bin/pip install --download-cache=/home/${APP_USER}/pip_cache -r ${PROJ_DIR}/requirements/common.txt",
+    command => "${VENV_DIR}/bin/pip install -r ${PROJ_DIR}/requirements/common.txt",
     timeout => 1800,
-  }
-
-  file {"/home/${APP_USER}/pip_cache":
-    ensure => directory,
-    owner  => "${APP_USER}",
-    group  => "${APP_GROUP}",
   }
 
   file { "vendor.pth":

--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -52,7 +52,7 @@ class python {
     "create-virtualenv":
     cwd => "/home/${APP_USER}",
     user => "${APP_USER}",
-    command => "virtualenv --no-site-packages ${VENV_DIR}",
+    command => "virtualenv ${VENV_DIR}",
     creates => "${VENV_DIR}",
     require => Exec["install-virtualenv"],
   }


### PR DESCRIPTION
* Don't use out of date pip/virtualenv packages …
We use an Ubuntu Precise image for the Vagrant project, whose package repository contains extremely out of date versions of setuptools, pip and virtualenv. So we stop using the package repository, and instead use the official PyPA bootstrap script, which installs the latest versions of setuptools and pip, and then we follow that with a pip install of the latest virtualenv. We need curl to fetch the pip bootstrap script, but it's handy for development anyway.
References to distribute are removed, since it's an older fork of setuptools and long since deprecated.

* Remove deprecated --download-cache pip option …
pip v6+ has an on by default cache, that it manages itself, so the --download-cache option is deprecated: 
https://pip.pypa.io/en/latest/reference/pip_install.html#caching

* Remove deprecated --no-site-packages venv option …
no-site-packages has been the default since virtualenv 1.7 (2011-11-30):
https://virtualenv.pypa.io/en/latest/reference.html#cmdoption--no-site-packages