### PR TITLE
Bug 1137164 - Docker: Use ./setup.py since current directory not on path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ RUN apt-get update && apt-get install -yq --force-yes mysql-client
 COPY ./requirements/common.txt /app/requirements.txt
 COPY ./docker/etc/profile.d/treeherder.sh /etc/profile.d/treeherder.sh
 COPY . /app
-RUN bin/peep.py install -r requirements.txt
-RUN setup.py build_ext --inplace
+RUN ./bin/peep.py install -r requirements.txt
+RUN ./setup.py build_ext --inplace
 RUN mkdir -p /var/log/gunicorn && mkdir -p /var/log/treeherder/


### PR DESCRIPTION
The current directory isn't on the PATH, so the docker build was failing with:
/bin/sh: 1: setup.py: not found

The bin/peep.py call was fine, but I've changed it for consistency.