### PR TITLE
Bug 1113322 - Tier n jobs

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -56,6 +56,7 @@ def test_job_list(webapp, eleven_jobs_processed, jm):
         "failure_classification_id",
         "pending_eta",
         "running_eta",
+        "tier",
         "last_modified",
         "ref_data_name"
     ]

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -76,8 +76,9 @@
                 `start_timestamp`,
                 `end_timestamp`,
                 `pending_eta`,
-                `running_eta`)
-                SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
+                `running_eta`,
+                `tier`)
+                SELECT ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?
                 FROM DUAL WHERE NOT EXISTS (
                     SELECT `job_guid`
                     FROM `job`
@@ -301,7 +302,7 @@
         },
         "update_last_job_classification":{
             "sql":"UPDATE job j
-                    SET failure_classification_id = ( 
+                    SET failure_classification_id = (
                         SELECT
                             IFNULL(
                                 ( SELECT
@@ -546,6 +547,8 @@
                     j.`submit_timestamp`,
                     j.`pending_eta`,
                     j.`running_eta`,
+                    j.`last_modified`,
+                    j.`tier`,
                     rds.`name` as ref_data_name,
                     rds.`build_system_type` as build_system_type
                   FROM `job` as j
@@ -599,6 +602,7 @@
                     j.`pending_eta`,
                     j.`running_eta`,
                     j.`last_modified`,
+                    j.`tier`,
                     rds.`name` as ref_data_name,
                     rds.`build_system_type` as build_system_type
                   FROM `job` as j

--- a/treeherder/model/sql/template_schema/project_jobs_1.sql.tmpl
+++ b/treeherder/model/sql/template_schema/project_jobs_1.sql.tmpl
@@ -126,6 +126,7 @@ CREATE TABLE `job` (
   `last_modified` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `pending_eta` int(10) unsigned DEFAULT NULL,
   `running_eta` int(10) unsigned DEFAULT NULL,
+  `tier` int(10) unsigned DEFAULT 1,
   `active_status` enum('active','onhold','deleted') COLLATE utf8_bin DEFAULT 'active',
   PRIMARY KEY (`id`),
   KEY `idx_job_guid` (`job_guid`),
@@ -150,6 +151,7 @@ CREATE TABLE `job` (
   KEY `idx_last_modified` (`last_modified`),
   KEY `idx_pending_eta` (`pending_eta`),
   KEY `idx_running` (`running_eta`),
+  KEY `idx_tier` (`tier`),
   KEY `idx_active_status` (`active_status`),
   CONSTRAINT `fk_result_set` FOREIGN KEY (`result_set_id`) REFERENCES `result_set` (`id`)
 ) ENGINE={engine} DEFAULT CHARSET=utf8 COLLATE=utf8_bin;


### PR DESCRIPTION
Add support for Tier 2 jobs
Fixes [bug 1113322](https://bugzilla.mozilla.org/show_bug.cgi?id=1113322)

* Add a ``tier`` field to the job table to establish whether a job is tier 1 or 2.  Default to 1
* Check for existence of a ``Tier-2`` exclusion profile.  Any job matching a signature in this profile will get its ``tier`` field set to 2.

Before merging this, must get a DBA to add the ``tier`` field to all the ``job`` tables.