### PR TITLE
Bug 1150734 - add signature field to jobs in job list

### DIFF
--- a/tests/webapp/api/test_jobs_api.py
+++ b/tests/webapp/api/test_jobs_api.py
@@ -58,7 +58,8 @@ def test_job_list(webapp, eleven_jobs_processed, jm):
         "running_eta",
         "tier",
         "last_modified",
-        "ref_data_name"
+        "ref_data_name",
+        "signature"
     ]
     for job in jobs:
         assert set(job.keys()) == set(exp_keys)

--- a/treeherder/model/derived/jobs.py
+++ b/treeherder/model/derived/jobs.py
@@ -122,6 +122,7 @@ class JobsModel(TreeherderModelBase):
             "start_timestamp": "j.start_timestamp",
             "end_timestamp": "j.end_timestamp",
             "last_modified": "j.last_modified",
+            "signature": "j.signature",
             "tier": "j.tier"
         },
         "result_set": {

--- a/treeherder/model/sql/jobs.json
+++ b/treeherder/model/sql/jobs.json
@@ -573,6 +573,7 @@
             "sql":"SELECT
                     j.id,
                     j.`job_guid`,
+                    j.`signature`,
                     j.`job_coalesced_to_guid`,
                     j.`build_platform_id`,
                     j.`option_collection_hash`,


### PR DESCRIPTION
This allows for more precise filtering with the ``job`` (buildername)
link in the detail panel.