### PR TITLE
Bug 1089639 - Add treeherder hostname to Vagrantfile for a clean up

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "precise32"
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
 
+  config.vm.hostname = "local.treeherder.mozilla.org"
   config.vm.network "private_network", ip: "192.168.33.10"
 
   config.vm.synced_folder ".", "/home/vagrant/treeherder-service", type: "nfs"


### PR DESCRIPTION
This fixes Bugzilla bug [1089639](https://bugzilla.mozilla.org/show_bug.cgi?id=1089639).

This eliminates the warning:
`warning: Could not retrieve fact fqdn`

during a `vagrant up`, when creating a local treeherder instance.

I only did one destroy and up, but it seems to be fine and behaving as expected. I am assuming we use the same hostname we specify in [RTD](https://treeherder-service.readthedocs.org/en/latest/installation.html#setting-up-a-local-treeherder-instance), rather than vagrant.example.com

I've confirmed the error goes away during an up, and the server seems fine and ingesting jobs with a local service.

Tested on OSX 10.9.5:
FF Release **36.0.4**
Chrome Latest Release **41.0.2272.104** (64-bit)

Adding @edmorley for review.