### PR TITLE
Bug 1151868 - Vagrant: Pin virtualenv to v12.0.7

### DIFF
--- a/puppet/manifests/classes/python.pp
+++ b/puppet/manifests/classes/python.pp
@@ -43,7 +43,7 @@ class python {
   exec { "install-virtualenv":
     cwd => "/tmp",
     user => "${APP_USER}",
-    command => "sudo pip install virtualenv",
+    command => "sudo pip install virtualenv==12.0.7",
     creates => "/usr/local/bin/virtualenv",
     require => Exec["install-pip"],
   }


### PR DESCRIPTION
Since higher versions include pip 6.1.1, which is currently incompatible with peep.
Virtualenv v12.0.7 ships with pip 6.0.8.