### PR TITLE
Bug 1151629 - Don't limit the number of bugs retrieved by fetch_bugs

### DIFF
--- a/treeherder/etl/bugzilla.py
+++ b/treeherder/etl/bugzilla.py
@@ -36,10 +36,7 @@ class BzApiBugProcess(JsonExtractorMixin):
         offset = 0
         limit = 500
 
-        # fetch new pages no more than 30 times
-        # this is a safe guard to not generate an infinite loop
-        # in case something went wrong
-        for i in range(1, 30 + 1):
+        while True:
             # fetch the bugzilla service until we have an empty result
             paginated_url = "{0}&offset={1}&limit={2}".format(
                 get_bz_source_url(),
@@ -51,11 +48,9 @@ class BzApiBugProcess(JsonExtractorMixin):
             bug_list += temp_bug_list
             if len(temp_bug_list) < limit:
                 break
-            else:
-                offset += limit
+            offset += limit
 
         if bug_list:
-
             for bug in bug_list:
                 # drop the timezone indicator to avoid issues with mysql
                 bug["last_change_time"] = bug["last_change_time"][0:19]


### PR DESCRIPTION
Previously we limited the number of pages to 30, which with a page size of 500, meant a max of 15,000 intermittent-failure bugs retrieved from Bugzilla, with no exceptions or log output to indicate this had occurred.

We now have more than 15,000 intermittent failure bugs, so the limit is being removed, since we're both confident that the search terms are correct, and any other infinite loop would be caught by the existing 600s timeout.

The task currently takes ~300s to run, so there is still plenty of headroom. Plus a timeout exception would be immediately visible in New Relic and so much less of a pain to debug.