### PR TITLE
Bug 1152426 - Only add bugs modified in the last year to the bugscache

### DIFF
--- a/treeherder/etl/bugzilla.py
+++ b/treeherder/etl/bugzilla.py
@@ -14,6 +14,7 @@ def get_bz_source_url():
     hostname = settings.BZ_API_URL
     params = {
         'keywords': 'intermittent-failure',
+        'chfieldfrom': '-1y',
         'include_fields': ('id,summary,status,resolution,'
                            'op_sys,cf_crash_signature, '
                            'keywords, last_change_time')


### PR DESCRIPTION
The API query will now be of form:
bugzilla.mozilla.org/rest/bug?include_fields=id,summary,status&keywords=intermittent-failure&chfieldfrom=-1y

To test, try using shorter values, eg:
https://bugzilla.mozilla.org/rest/bug?include_fields=id,summary,status&keywords=intermittent-failure&chfieldfrom=-6h

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/treeherder-service/460)
<!-- Reviewable:end -->
